### PR TITLE
Update from update/Mixaster995/test-actions-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/Mixaster995/test-actions-3
 
 go 1.16
 
-require (
-	github.com/Mixaster995/test-actions v0.0.0-20210727072257-5ce91ef45250 // indirect
-	github.com/Mixaster995/test-actions-2 v0.0.0-20210727075519-7c7b7aed385e // indirect
-)
+require github.com/Mixaster995/test-actions-2 v0.0.0-20210728033706-30123a71d290

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
-github.com/Mixaster995/test-actions v0.0.0-20210727050445-2c5f97f5ab2b/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
-github.com/Mixaster995/test-actions v0.0.0-20210727072257-5ce91ef45250 h1:rN+jC15BsMS3u8YfEpc+vmTS9m75stI37bACU37t6Uo=
-github.com/Mixaster995/test-actions v0.0.0-20210727072257-5ce91ef45250/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210727075142-87d87b2bc82b h1:eCs/ueTLnv1WUGLrzYCfjCDw7yZ/EH+bdJkR49/Fxsc=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210727075142-87d87b2bc82b/go.mod h1:b60i8NJjbOKUh/zzszUvz9p+cbhZ3CXKKaHaPxRQBeI=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210727075519-7c7b7aed385e h1:PSM8JCafEYerYAcsFks/ejM9V3yhF0/rcpITRpcaNmo=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210727075519-7c7b7aed385e/go.mod h1:b60i8NJjbOKUh/zzszUvz9p+cbhZ3CXKKaHaPxRQBeI=
+github.com/Mixaster995/test-actions v0.0.0-20210728033551-b34c6896205c h1:xanOHdN8VvZ9cyx6eQD9gcWQDmI2Fz+BfrZlvFyEh+0=
+github.com/Mixaster995/test-actions v0.0.0-20210728033551-b34c6896205c/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210728033706-30123a71d290 h1:1hRH1hfBHaCC/6737GSGl5wk5dwwhSBlpo8D/eqUTsU=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210728033706-30123a71d290/go.mod h1:czAvLDeo43tBGoRgOz6y3SwZNk7KGkGYPqjp1mt55fI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
Date: 2021-07-28 03:37:22 +0000
Update go.mod and go.sum to latest version from Mixaster995/test-actions-2@main
PR link: https://github.com/Mixaster995/test-actions-2/pull/
- Commit: 30123a7
Author: Авраменко Михаил
Date: 2021-07-28 10:37:06 +0700
Message:Update go.mod and go.sum to latest version from Mixaster995/test-acti…