### PR TITLE
Update from update/Mixaster995/test-actions-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-3
 
 go 1.16
 
-require github.com/Mixaster995/test-actions-2 v0.0.0-20210728041535-b582371b8108
+require github.com/Mixaster995/test-actions-2 v0.0.0-20210728075756-525aedac8472

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/Mixaster995/test-actions v0.0.0-20210728041429-0a03bc042c0a h1:dUoWGMoJhp2fZeJeyRzODPChmIBoI2WjaGc7PJpQr8o=
-github.com/Mixaster995/test-actions v0.0.0-20210728041429-0a03bc042c0a/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210728041535-b582371b8108 h1:OchQBZtydJTYnOHnxbDyEX801r0ipchfpaaPpE7JjSI=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210728041535-b582371b8108/go.mod h1:iqbiMKUeI1lBAjBS5JilYKAQFvUK29/Hq6Yw34ouNIg=
+github.com/Mixaster995/test-actions v0.0.0-20210728055134-9ff9680a5b39 h1:Pnceg4aF4F9UC9g47dT96mCTqVb4NawfIW4718+46yQ=
+github.com/Mixaster995/test-actions v0.0.0-20210728055134-9ff9680a5b39/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210728075756-525aedac8472 h1:I0I1Jj5Mco8SUzWqBJiiv/BobJtZp7QC5NgmmDuwV0Y=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210728075756-525aedac8472/go.mod h1:xxbuZDfWKc5IM43VaZjLUUv3Q8TdM8bZjaIud7Ru/8w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Date: 2021-07-28 07:58:35 +0000
- Update go.mod and go.sum to latest version from Mixaster995/test-actions-2@main
PR link: https://github.com/Mixaster995/test-actions-2/pull/