### PR TITLE
Update from update/Mixaster995/test-actions-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Mixaster995/test-actions-3
 
 go 1.16
 
-require github.com/Mixaster995/test-actions-2 v0.0.0-20210730071907-b48ab5c85657
+require github.com/Mixaster995/test-actions-2 v0.0.0-20210810054509-32f9dae3285e

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Mixaster995/test-actions v0.0.0-20210730071747-94ae71f45461 h1:r2GrOSLfxccp0w2UAVmw3XCF69+L9PjQl7Wzkjxd3Uo=
 github.com/Mixaster995/test-actions v0.0.0-20210730071747-94ae71f45461/go.mod h1:oEJFEJuf86fxm+L3Fb2fExUNBTZfCimHyX0hUICMEUo=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210730071907-b48ab5c85657 h1:5Z+mVUvQed5Ei+N/hK86sy6BChx+FjF2uMYxFAHbrMM=
-github.com/Mixaster995/test-actions-2 v0.0.0-20210730071907-b48ab5c85657/go.mod h1:dOMp+W0pwiB//aqv8BXrXBAyPMb+VgJU8eelBkTB8oc=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210810054509-32f9dae3285e h1:yhOF08HU0x5j52c7rcubcQhMhfwVrcj0ZiFq9sJyeSg=
+github.com/Mixaster995/test-actions-2 v0.0.0-20210810054509-32f9dae3285e/go.mod h1:dOMp+W0pwiB//aqv8BXrXBAyPMb+VgJU8eelBkTB8oc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Update go.mod and go.sum to latest version from Mixaster995/test-actions-2@main
PR link: https://github.com/Mixaster995/test-actions-2/pull/
Commit: 32f9dae
Author: Mikhail Avramenko
Date: 2021-08-10 12:45:09 +0700
Message:
  - Merge branch 'master' of https://github.com/Mixaster995/test-actions-2